### PR TITLE
All Templates: Generate Tag/Category URLs using Parent Blog URL

### DIFF
--- a/blog/mvc/Views/Cms/Post.cshtml
+++ b/blog/mvc/Views/Cms/Post.cshtml
@@ -1,7 +1,9 @@
-@model MvcBlog.Models.BlogPost
+﻿@model MvcBlog.Models.BlogPost
 @inject Piranha.IApi Api
 @{
     ViewBag.Title = Model.Title;
+
+    var parentBlogContent = await Api.Pages.GetByIdAsync(Model.BlogId);
 }
 
 <div class="container">
@@ -13,12 +15,12 @@
             }
             <h1>@Model.Title</h1>
             <p class="post-meta">
-                <strong>In</strong> <a href="/category/@Model.Category.Slug">@Model.Category.Title</a>
+                <strong>In</strong> <a href="@parentBlogContent.Permalink/category/@Model.Category.Slug">@Model.Category.Title</a>
                 <span class="sep">&#9670;</span>
                 <strong>Tags</strong>
                 @foreach (var tag in Model.Tags)
                 {
-                    <span class="tag"><a href="/tag/@tag.Slug">#@tag.Title</a></span>
+                    <span class="tag"><a href="@parentBlogContent.Permalink/tag/@tag.Slug">#@tag.Title</a></span>
                 }
                 <span class="sep">&#9670;</span>
                 <strong>Published</strong>

--- a/blog/razor/Pages/Post.cshtml
+++ b/blog/razor/Pages/Post.cshtml
@@ -1,8 +1,10 @@
-@page
+﻿@page
 @model SinglePostModel<BlogPost>
 @inject Piranha.IApi Api
 @{
     ViewBag.Title = Model.Data.Title;
+
+    var parentBlogContent = await Api.Pages.GetByIdAsync(Model.Data.BlogId);
 }
 
 <div class="container">
@@ -14,12 +16,12 @@
             }
             <h1>@Model.Data.Title</h1>
             <p class="post-meta">
-                <strong>In</strong> <a href="/category/@Model.Data.Category.Slug">@Model.Data.Category.Title</a>
+                <strong>In</strong> <a href="@parentBlogContent.Permalink/category/@Model.Data.Category.Slug">@Model.Data.Category.Title</a>
                 <span class="sep">&#9670;</span>
                 <strong>Tags</strong>
                 @foreach (var tag in Model.Data.Tags)
                 {
-                    <span class="tag"><a href="/tag/@tag.Slug">#@tag.Title</a></span>
+                    <span class="tag"><a href="@parentBlogContent.Permalink/tag/@tag.Slug">#@tag.Title</a></span>
                 }
                 <span class="sep">&#9670;</span>
                 <strong>Published</strong>

--- a/enterprise/mvc/EnterpriseWeb.Web/Views/Blog/Post.cshtml
+++ b/enterprise/mvc/EnterpriseWeb.Web/Views/Blog/Post.cshtml
@@ -1,7 +1,9 @@
-@model BlogPost
+﻿@model BlogPost
 
 @{
     ViewBag.Title = Model.Title;
+
+    var parentBlogContent = await Api.Pages.GetByIdAsync(Model.BlogId);
 }
 
 <div class="main">
@@ -9,14 +11,17 @@
         <div class="row justify-content-center">
             <div class="col-sm-10 post-header">
                 <h1>@Model.Title</h1>
-                @if (Model.Tags.Count > 0) {
-                    foreach (var tag in Model.Tags) {
-                        <text><span class="tag"># @tag.Title</span></text>
+                @if (Model.Tags.Count > 0)
+                {
+                    foreach (var tag in Model.Tags)
+                    {
+                        <span class="tag"><a href="@parentBlogContent.Permalink/tag/@tag.Slug">#@tag.Title</a></span>
                     }
                 }
             </div>
         </div>
-        @if (Model.Hero.PrimaryImage.HasValue) {
+        @if (Model.Hero.PrimaryImage.HasValue)
+        {
             <div class="row">
                 <div class="col-sm post-header">
                     <img class="img-fluid" src="@Url.Content(Model.Hero.PrimaryImage.Resize(Api, 1100, 400))">

--- a/web/mvc/Views/Cms/Post.cshtml
+++ b/web/mvc/Views/Cms/Post.cshtml
@@ -1,8 +1,10 @@
-@model BlogPost
+﻿@model BlogPost
 @inject IApi Api
 
 @{
     ViewBag.Title = Model.Title;
+
+    var parentBlogContent = await Api.Pages.GetByIdAsync(Model.BlogId);
 }
 
 <div class="main">
@@ -10,14 +12,17 @@
         <div class="row justify-content-center">
             <div class="col-sm-10 post-header">
                 <h1>@Model.Title</h1>
-                @if (Model.Tags.Count > 0) {
-                    foreach (var tag in Model.Tags) {
-                        <text><span class="tag"># @tag.Title</span></text>
+                @if (Model.Tags.Count > 0)
+                {
+                    foreach (var tag in Model.Tags)
+                    {
+                        <span class="tag"><a href="@parentBlogContent.Permalink/tag/@tag.Slug">#@tag.Title</a></span>
                     }
                 }
             </div>
         </div>
-        @if (Model.Hero.PrimaryImage.HasValue) {
+        @if (Model.Hero.PrimaryImage.HasValue)
+        {
             <div class="row">
                 <div class="col-sm post-header">
                     <img class="img-fluid" src="@Url.Content(Model.Hero.PrimaryImage.Resize(Api, 1100, 400))">


### PR DESCRIPTION
For a long while now it has bugged me that the templates right out of the gates have broken links on the "post" page. The tag/category links were absolute `/tag/<tag-slug>` and would 404.

I've updated each of the samples to use the parent blog's permalink when generating links to blog-relative content actions.

Open to suggestions on other ways to do this, grabbing the blog page by id and using it's permalink just seemed easiest.

Worth noting that there's a single visual change in this commit, which is the "#<tag-name>" links on the MvcWeb/EnterpriseWeb post page templates were not actual links. This makes them links as well, changing their color to the expected blue.

![image](https://user-images.githubusercontent.com/1737733/70638861-34858f00-1bff-11ea-9775-7877b7c808d6.png)
