### PR TITLE
Updating to Pomelo.EntityFrameworkCore.MySql v5.0.0

### DIFF
--- a/src/web/mvc/Startup.cs
+++ b/src/web/mvc/Startup.cs
@@ -67,9 +67,9 @@ namespace MvcWeb
                     db.UseSqlServer(_config.GetConnectionString("piranha")));
 #elif (UseMySql)
                 options.UseEF<MySqlDb>(db =>
-                    db.UseMySql(_config.GetConnectionString("piranha")));
+                    db.UseMySql(_config.GetConnectionString("piranha")), ServerVersion.AutoDetect(_config.GetConnectionString("piranha")));
                 options.UseIdentityWithSeed<IdentityMySQLDb>(db =>
-                    db.UseMySql(_config.GetConnectionString("piranha")));
+                    db.UseMySql(_config.GetConnectionString("piranha"), ServerVersion.AutoDetect(_config.GetConnectionString("piranha"))));
 #elif (UsePostgreSql)
                 options.UseEF<PostgreSqlDb>(db =>
                     db.UseNpgsql(_config.GetConnectionString("piranha")));

--- a/src/web/razor/Startup.cs
+++ b/src/web/razor/Startup.cs
@@ -67,9 +67,9 @@ namespace RazorWeb
                     db.UseSqlServer(_config.GetConnectionString("piranha")));
 #elif (UseMySql)
                 options.UseEF<MySqlDb>(db =>
-                    db.UseMySql(_config.GetConnectionString("piranha")));
+                    db.UseMySql(_config.GetConnectionString("piranha")), ServerVersion.AutoDetect(_config.GetConnectionString("piranha")));
                 options.UseIdentityWithSeed<IdentityMySQLDb>(db =>
-                    db.UseMySql(_config.GetConnectionString("piranha")));
+                    db.UseMySql(_config.GetConnectionString("piranha"), ServerVersion.AutoDetect(_config.GetConnectionString("piranha"))));
 #elif (UsePostgreSql)
                 options.UseEF<PostgreSqlDb>(db =>
                     db.UseNpgsql(_config.GetConnectionString("piranha")));


### PR DESCRIPTION
**Changes:**

- Adds new MySQL connection configuration to MVC and Razor Templates.
- Uses `ServerVersion.AutoDetect()` to make template compatible with all supported MySQL versions.