### PR TITLE
Fixing gulp file and packages

### DIFF
--- a/src/web/mvc/gulpfile.js
+++ b/src/web/mvc/gulpfile.js
@@ -1,7 +1,22 @@
+const { watch } = require('gulp');
 var gulp = require('gulp'),
-    sass = require('gulp-sass')
-    cssmin = require("gulp-cssmin")
-    rename = require("gulp-rename");
+    sass = require('gulp-sass')(require('sass'))
+cssmin = require("gulp-cssmin")
+rename = require("gulp-rename");
+
+gulp.task('watch', function (done) {
+    // All events will be watched
+    watch('assets/scss/inc/*.scss', { events: 'all' }, function (cb) {
+        gulp.src('assets/scss/style.scss')
+            .pipe(sass().on('error', sass.logError))
+            .pipe(cssmin())
+            .pipe(rename({
+                suffix: ".min"
+            }))
+            .pipe(gulp.dest('wwwroot/assets/css'));
+        cb();
+    });
+});
 
 gulp.task('min', function (done) {
     gulp.src('assets/scss/style.scss')
@@ -14,5 +29,3 @@ gulp.task('min', function (done) {
     done();
 });
 
-gulp.task("serve", gulp.parallel(["min"]));
-gulp.task("default", gulp.series("serve"));

--- a/src/web/mvc/package.json
+++ b/src/web/mvc/package.json
@@ -9,6 +9,8 @@
     "gulp": "^4.0.2",
     "gulp-cssmin": "^0.2.0",
     "gulp-rename": "^2.0.0",
-    "gulp-sass": "^4.0.2"
+    "gulp-sass": "^5.1.0",
+    "gulp-watch": "^5.0.1",
+    "sass": "^1.69.5"
   }
 }

--- a/src/web/razor/gulpfile.js
+++ b/src/web/razor/gulpfile.js
@@ -1,7 +1,22 @@
+const { watch } = require('gulp');
 var gulp = require('gulp'),
-    sass = require('gulp-sass')
-    cssmin = require("gulp-cssmin")
-    rename = require("gulp-rename");
+    sass = require('gulp-sass')(require('sass'))
+cssmin = require("gulp-cssmin")
+rename = require("gulp-rename");
+
+gulp.task('watch', function (done) {
+    // All events will be watched
+    watch('assets/scss/inc/*.scss', { events: 'all' }, function (cb) {
+        gulp.src('assets/scss/style.scss')
+            .pipe(sass().on('error', sass.logError))
+            .pipe(cssmin())
+            .pipe(rename({
+                suffix: ".min"
+            }))
+            .pipe(gulp.dest('wwwroot/assets/css'));
+        cb();
+    });
+});
 
 gulp.task('min', function (done) {
     gulp.src('assets/scss/style.scss')
@@ -13,6 +28,3 @@ gulp.task('min', function (done) {
         .pipe(gulp.dest('wwwroot/assets/css'));
     done();
 });
-
-gulp.task("serve", gulp.parallel(["min"]));
-gulp.task("default", gulp.series("serve"));

--- a/src/web/razor/package.json
+++ b/src/web/razor/package.json
@@ -9,6 +9,8 @@
     "gulp": "^4.0.2",
     "gulp-cssmin": "^0.2.0",
     "gulp-rename": "^2.0.0",
-    "gulp-sass": "^4.0.2"
+    "gulp-sass": "^5.1.0",
+    "gulp-watch": "^5.0.1",
+    "sass": "^1.69.5"
   }
 }


### PR DESCRIPTION
Current package file will not install with npm or yarn. It will create issues with python 2.7 missing and generate a lot of errors.
Added new feature to the gulp file called watch.

By running the command 'gulp watch' you will trigger a new build of the sass and css files which update the project you are working on.