### PR TITLE
Fix breaking changes of Bootstrap 5

### DIFF
--- a/src/web/razor/Pages/_Layout.cshtml
+++ b/src/web/razor/Pages/_Layout.cshtml
@@ -19,12 +19,12 @@
     <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
         <div class="container">
             <a class="navbar-brand" href="~/">Piranha CMS <small>@version</small></a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
 
             <div class="collapse navbar-collapse" id="navbarsExampleDefault">
-                <ul class="navbar-nav ml-auto">
+                <ul class="navbar-nav ms-auto">
                     @foreach (var item in (await WebApp.Site.Sitemap.ForUserAsync(User, Auth)).Where(i => !i.IsHidden))
                     {
                     <li class="nav-item@(item.Id == WebApp.PageId || item.HasChild(WebApp.PageId) ? " active" : "")">


### PR DESCRIPTION
The drawer in the collapsed menu fails to appear when triggered. The issue is due to breaking changes between Bootstrap 4 and Bootstrap 5. In Bootstrap 5: The data-toggle and data-target attributes have been replaced with data-bs-toggle and data-bs-target. The margin utility classes have also changed; ml-auto (Bootstrap 4) is now ms-auto (Bootstrap 5).